### PR TITLE
adds build badge

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -35,7 +35,6 @@ jobs:
       run: |
         mkdir ${HOME}/.kube
         echo ${{ secrets.KUBE_CONFIG }} | base64 --decode > ${HOME}/.kube/config
-        cat ${HOME}/.kube/config
     - name: Use context
       run: kubectl config use-context octobay-api
     - name: Deploy to K8s

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OctoBay API
 
+![OctoBay API Dev](https://github.com/octobay/api/actions/workflows/node.js.yml/badge.svg)
+
 ## GitHub
 
 <details>


### PR DESCRIPTION
adds a build badge to show if the build is passing

shows how we can add the same for OctoBay badges with a /BADGE.svg endpoint we can create for funded repos